### PR TITLE
Updates to improve thumbnail scrolling

### DIFF
--- a/src/components/DocumentPage/ScrollingPage.vue
+++ b/src/components/DocumentPage/ScrollingPage.vue
@@ -44,10 +44,12 @@ export default {
       previousFocusedAnnotation: null,
       previousY: null,
       pageBeingLoaded: false,
+      isScrolling: false,
     };
   },
 
   computed: {
+    ...mapState("display", ["pageChangedFromThumbnail"]),
     ...mapGetters("display", ["visiblePageRange", "bboxToRect"]),
     ...mapGetters("document", ["scrollDocumentToAnnotation"]),
 
@@ -117,15 +119,12 @@ export default {
       }
     },
     isElementFocused(focused) {
-      if (!this.loading && focused) {
+      if (!this.loading && focused && !this.pageChangedFromThumbnail) {
         this.$store.dispatch("display/updateCurrentPage", this.page.number);
       }
     },
     currentPage(number) {
-      if (
-        (this.page.number === number || this.page.number === number) &&
-        !this.isElementFocused
-      ) {
+      if (this.page.number === number && !this.isElementFocused) {
         this.$emit("page-jump", this.elementTop, 0);
       }
     },

--- a/src/components/DocumentThumbnails/DocumentThumbnails.vue
+++ b/src/components/DocumentThumbnails/DocumentThumbnails.vue
@@ -62,7 +62,7 @@ export default {
   },
   data() {
     return {
-      thumbnailClicked: false,
+      thumbnailClicked: null,
       previousScrollPosition: 0,
     };
   },
@@ -76,9 +76,10 @@ export default {
   },
   watch: {
     currentPage(newPage) {
-      if (newPage && !this.thumbnailClicked) {
-        this.scrollToThumbnail();
-      }
+      if (!newPage) return;
+
+      // handle thumbnail selection when scrolling the document
+      this.scrollToThumbnail(newPage);
     },
   },
   mounted() {
@@ -94,27 +95,29 @@ export default {
   methods: {
     /* Change page if not the currently open and not in modal */
     changePage(pageNumber) {
-      this.thumbnailClicked = true;
+      this.thumbnailClicked = pageNumber;
 
       if (
         !this.loading &&
         !this.recalculatingAnnotations &&
         pageNumber != this.currentPage
       ) {
-        this.$store.dispatch(
-          "display/updateCurrentPage",
-          parseInt(pageNumber, 10)
-        );
+        this.$store.dispatch("display/setPageChangedFromThumbnail", true);
+        this.$store.dispatch("display/updateCurrentPage", pageNumber);
       }
     },
 
-    scrollToThumbnail() {
+    scrollToThumbnail(page) {
       // select only the active thumbnail
       const selectedPage = this.$refs.docPage.filter((image) =>
         image.className.includes("selected")
       );
 
-      if (selectedPage && selectedPage[0]) {
+      if (page == this.thumbnailClicked) {
+        this.thumbnailClicked = null;
+      }
+
+      if (!this.thumbnailClicked && selectedPage && selectedPage[0]) {
         selectedPage[0].scrollIntoView();
       }
     },

--- a/src/store/display.js
+++ b/src/store/display.js
@@ -29,6 +29,7 @@ const state = {
   interactionBlocked: false,
   documentActionBar: null, // document action bar properties
   categorizeModalIsActive: false,
+  pageChangedFromThumbnail: false,
 };
 
 const getters = {
@@ -209,6 +210,9 @@ const actions = {
   setCategorizeModalIsActive: ({ commit }, value) => {
     commit("SET_CATEGORIZE_MODAL_IS_ACTIVE", value);
   },
+  setPageChangedFromThumbnail: ({ commit }, value) => {
+    commit("SET_PAGE_CHANGED_FROM_THUMBNAIL", value);
+  },
 };
 
 const mutations = {
@@ -234,6 +238,9 @@ const mutations = {
 
   SET_CATEGORIZE_MODAL_IS_ACTIVE: (state, value) => {
     state.categorizeModalIsActive = value;
+  },
+  SET_PAGE_CHANGED_FROM_THUMBNAIL: (state, value) => {
+    state.pageChangedFromThumbnail = value;
   },
 };
 


### PR DESCRIPTION
To fix the intermediate selection when trying to change a Document Page by clicking on its specific thumbnail, and other thumbnails in between getting selected due to other Document Pages being within the visible page range during the scrolling event.