### PR TITLE
Create separate store and other modules for unit tests

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,9 +1,12 @@
 import Vue from "vue";
 import Buefy from "buefy";
 import VueObserveVisibility from "vue-observe-visibility";
+import { init as initStore } from "./utils/store";
 
 Vue.use(VueObserveVisibility);
 Vue.use(Buefy);
+
+initStore();
 
 // Mock IntersectionObserver
 global.IntersectionObserver = class IntersectionObserver {

--- a/tests/unit/DocumentPage.spec.js
+++ b/tests/unit/DocumentPage.spec.js
@@ -1,96 +1,30 @@
-import { mount, shallowMount } from "@vue/test-utils";
-import {
-  ScrollingDocument,
-  ScrollingPage,
-  ToolBar,
-} from "../../src/components/DocumentPage";
-import store from "../../src/store";
-
-// mock i18n so we don't need to load the library
-const $t = () => {};
+import { render } from "../utils/render";
+import { getData, getGetter } from "../utils/store";
+import { ScrollingDocument, ToolBar } from "../../src/components/DocumentPage";
 
 describe("Document Page Component", () => {
-  const annotations = [];
-  require("../mock/document.json").annotation_sets.map((annotationSet) => {
-    annotationSet.labels.map((label) => {
-      annotations.push(...label.annotations);
-    });
-  });
-
-  // mock scale for scrolling pages
-  const scale = {
-    elementsWidth: 1,
-    client: {
-      width: 1600,
-      height: 1200,
-    },
-    viewport: {
-      width: require("../mock/page_1.json").size[0],
-      height: require("../mock/page_1.json").size[1],
-    },
-  };
-
-  beforeEach(() => {
-    Promise.all([
-      store.dispatch(
-        "document/setSelectedDocument",
-        require("../mock/document.json")
-      ),
-      store.dispatch("document/setAnnotations", annotations),
-      store.dispatch("document/setPages", [
-        require("../mock/page_1.json"),
-        require("../mock/page_2.json"),
-      ]),
-      store.dispatch("document/endRecalculatingAnnotations"),
-      store.dispatch("document/endLoading"),
-      store.dispatch("display/updateScale", scale),
-      store.dispatch("document/setPublicView", false),
-    ]);
-  });
-
   it("document contains two scrolling pages", async () => {
-    const wrapper = shallowMount(ScrollingDocument, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(ScrollingDocument, true);
 
     expect(await wrapper.findAll(".scrolling-page").length).toBe(2);
   });
 
   it("document should have page 1 visible", async () => {
-    mount(ScrollingDocument, {
-      store,
-      propsData: {
-        pages: store.state.document.pages,
-      },
-      mocks: {
-        $t,
-      },
+    render(ScrollingDocument, false, {
+      pages: getData("document").pages,
     });
 
-    expect(store.getters["display/visiblePageRange"]).toContain(1);
+    expect(getGetter("display/visiblePageRange")).toContain(1);
   });
 
   it("Toolbar should be visible", async () => {
-    const wrapper = shallowMount(ToolBar, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(ToolBar, true);
 
     expect(await wrapper.findComponent(".toolbar-container"));
   });
 
   it("Toolbar should have icons and text visible", async () => {
-    const wrapper = shallowMount(ToolBar, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(ToolBar, true);
 
     expect(await wrapper.findComponent(".edit-icon").exists()).toBe(true);
     expect(await wrapper.findComponent(".edit-text").exists()).toBe(true);

--- a/tests/unit/DocumentThumbnails.spec.js
+++ b/tests/unit/DocumentThumbnails.spec.js
@@ -1,73 +1,28 @@
-import { shallowMount } from "@vue/test-utils";
+import { render } from "../utils/render";
 import { DocumentThumbnails } from "../../src/components/DocumentThumbnails";
-import store from "../../src/store";
-
-// mock i18n so we don't need to load the library
-const $t = () => {};
 
 describe("Document Thumbnails Component", () => {
-  const annotations = [];
-  require("../mock/document.json").annotation_sets.map((annotationSet) => {
-    annotationSet.labels.map((label) => {
-      annotations.push(...label.annotations);
-    });
-  });
-  const documentData = require("../mock/document.json");
-  const pages = [
-    require("../mock/page_1.json"),
-    require("../mock/page_2.json"),
-  ];
-  documentData.pages = pages;
-  beforeEach(() => {
-    Promise.all([
-      store.dispatch("document/setSelectedDocument", documentData),
-      store.dispatch("document/setAnnotations", annotations),
-      store.dispatch("document/setPages", pages),
-      store.dispatch("document/endRecalculatingAnnotations"),
-      store.dispatch("document/endLoading"),
-    ]);
-  });
   it("check number of thumbnails", async () => {
-    const wrapper = shallowMount(DocumentThumbnails, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(DocumentThumbnails, true);
     expect(await wrapper.findAll(".document-thumbnail").length).toEqual(2);
   });
 
   it("check if first thumbnail is selected", async () => {
-    const wrapper = shallowMount(DocumentThumbnails, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(DocumentThumbnails, true);
     expect(await wrapper.findAll(".img-thumbnail").at(0).classes()).toContain(
       "selected"
     );
   });
 
   it("check if second thumbnail is not selected", async () => {
-    const wrapper = shallowMount(DocumentThumbnails, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(DocumentThumbnails, true);
     expect(
       await wrapper.findAll(".img-thumbnail").at(1).classes()
     ).not.toContain("selected");
   });
 
   it("check if second thumbnail has text 2", async () => {
-    const wrapper = shallowMount(DocumentThumbnails, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(DocumentThumbnails, true);
     expect(await wrapper.findAll(".number-thumbnail").at(1).text()).toBe("2");
   });
 });

--- a/tests/unit/DocumentTopBar.spec.js
+++ b/tests/unit/DocumentTopBar.spec.js
@@ -1,81 +1,35 @@
-import { mount, shallowMount } from "@vue/test-utils";
-import {
-  DocumentTopBar,
-  DocumentName,
-} from "../../src/components/DocumentTopBar";
+import { render } from "../utils/render";
+import { dispatch, getData } from "../utils/store";
 import { DocumentCategory } from "../../src/components";
-import store from "../../src/store";
-
-// mock i18n so we don't need to load the library
-const $t = () => {};
+import {
+  DocumentName,
+  DocumentTopBar,
+} from "../../src/components/DocumentTopBar";
 
 describe("Document Top Bar", () => {
-  // Set file name
-  const documentData = require("../mock/document.json");
-  const pages = [
-    require("../mock/page_1.json"),
-    require("../mock/page_2.json"),
-  ];
-  documentData.pages = pages;
-
-  beforeEach(() => {
-    Promise.resolve(
-      store.dispatch("document/setSelectedDocument", documentData),
-      store.dispatch(
-        "document/setAnnotationSets",
-        require("../mock/document.json").annotation_sets
-      ),
-      store.dispatch("document/setPublicView", false),
-      store.dispatch("document/endRecalculatingAnnotations"),
-      store.dispatch("document/endLoading")
-    );
-  });
-
   it("Document Top Bar should be rendered", async () => {
-    const wrapper = shallowMount(DocumentTopBar, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(DocumentTopBar, true);
 
     expect(await wrapper.getComponent(".document-top-bar-component"));
   });
 
   it("File name should be visible", () => {
-    const wrapper = shallowMount(DocumentName, {
-      store,
-      propsData: {
-        dataFileName: store.state.document.selectedDocument.data_file_name,
-      },
-      mocks: {
-        $t,
-      },
+    const fileName = getData("document").selectedDocument.data_file_name;
+    const wrapper = render(DocumentName, true, {
+      dataFileName: fileName,
     });
 
-    expect(wrapper.getComponent(".document-name").text()).toBe(
-      documentData.data_file_name
-    );
+    expect(wrapper.getComponent(".document-name").text()).toBe(fileName);
   });
 
   it("Edit button should be visible when rendering the component", async () => {
-    const wrapper = shallowMount(DocumentName, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(DocumentName, true);
 
     expect(await wrapper.findComponent(".edit-btn").exists()).toBe(true);
   });
 
   it("Clicking on the edit button should make it not visible and make the save one visible", async () => {
-    const wrapper = mount(DocumentTopBar, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(DocumentTopBar, false);
 
     await wrapper.getComponent(".edit-btn").trigger("click");
     expect(await wrapper.findComponent(".edit-btn").exists()).toBe(false);
@@ -83,12 +37,7 @@ describe("Document Top Bar", () => {
   });
 
   it("No buttons should be visible while saving", async () => {
-    const wrapper = mount(DocumentTopBar, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(DocumentTopBar, false);
 
     await wrapper.getComponent(".edit-btn").trigger("click");
     expect(await wrapper.findComponent(".edit-btn").exists()).toBe(false);
@@ -98,12 +47,7 @@ describe("Document Top Bar", () => {
   });
 
   it("The file name should become a content editable when clicking on the Edit button", async () => {
-    const wrapper = mount(DocumentTopBar, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(DocumentTopBar, false);
 
     await wrapper.getComponent(".edit-btn").trigger("click");
     expect(wrapper.getComponent(".document-name").classes()).toContain(
@@ -112,12 +56,7 @@ describe("Document Top Bar", () => {
   });
 
   it("The file name should not be content editable after clicking the Save button", async () => {
-    const wrapper = mount(DocumentTopBar, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(DocumentTopBar, false);
 
     await wrapper.getComponent(".edit-btn").trigger("click");
     await wrapper.getComponent(".save-btn").trigger("click");
@@ -127,12 +66,7 @@ describe("Document Top Bar", () => {
   });
 
   it("Clicking the save button should show the autosaving message to the user", async () => {
-    const wrapper = mount(DocumentTopBar, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(DocumentTopBar, false);
 
     await wrapper.getComponent(".edit-btn").trigger("click");
     await wrapper.getComponent(".save-btn").trigger("click");
@@ -142,12 +76,7 @@ describe("Document Top Bar", () => {
   });
 
   it("Check if save function is called after clicking save button", async () => {
-    const wrapper = mount(DocumentTopBar, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(DocumentTopBar, false);
 
     const mockFn = jest.fn().mockName("saveFunction");
 
@@ -159,23 +88,13 @@ describe("Document Top Bar", () => {
   });
 
   it("Keyboard icon is visible", async () => {
-    const wrapper = mount(DocumentTopBar, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(DocumentTopBar, false);
 
     expect(await wrapper.find(".keyboard-actions-info").exists()).toBe(true);
   });
 
   it("Tooltip is visible on hover", async () => {
-    const wrapper = mount(DocumentTopBar, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(DocumentTopBar, false);
 
     await wrapper
       .findComponent(".keyboard-actions-info .tooltip-trigger")
@@ -189,12 +108,7 @@ describe("Document Top Bar", () => {
   });
 
   it("Finish review button should be visible if not in edit mode, public view or review finished", async () => {
-    const wrapper = mount(DocumentTopBar, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(DocumentTopBar, false);
 
     expect(
       await wrapper
@@ -204,12 +118,7 @@ describe("Document Top Bar", () => {
   });
 
   it("Finish review button should be disabled if review is not done", async () => {
-    const wrapper = mount(DocumentTopBar, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(DocumentTopBar, false);
 
     expect(
       await wrapper
@@ -221,14 +130,9 @@ describe("Document Top Bar", () => {
   });
 
   it("If document is in edit mode, button should not be visible", async () => {
-    const wrapper = mount(DocumentTopBar, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(DocumentTopBar, false);
 
-    await store.dispatch("edit/enableEditMode", true);
+    await dispatch("edit/enableEditMode", true);
 
     expect(
       await wrapper
@@ -240,14 +144,9 @@ describe("Document Top Bar", () => {
   });
 
   it("Should not show Category dropdown, option to edit file name, keyboard actions information or other buttons", async () => {
-    const wrapper = mount(DocumentTopBar, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(DocumentTopBar, false);
 
-    store.dispatch("document/setPublicView", true);
+    dispatch("document/setPublicView", true);
 
     const categoryDropdown = await wrapper.find(
       ".left-bar-components .dropdown"
@@ -272,25 +171,22 @@ describe("Document Top Bar", () => {
   });
 
   it("Category dropdown is disabled if the Document belongs to a dataset, or if there are Annotations that are correct", async () => {
-    const annotationSet = store.state.document.annotationSets[0];
+    const annotationSet = getData("document").annotationSets[0];
     const labels = annotationSet.labels;
     const annotations = labels.flatMap((label) => {
       return label.annotations;
     });
     const correctAnnotations = annotations.filter((ann) => ann.is_correct);
 
-    const wrapper = mount(DocumentCategory, {
-      store,
-      mocks: {
-        $t,
-      },
-      data() {
-        return {
-          dropdownIsDisabled: false,
-          tooltipIsShown: false,
-        };
-      },
-    });
+    const wrapper = render(
+      DocumentCategory,
+      false,
+      {},
+      {
+        dropdownIsDisabled: false,
+        tooltipIsShown: false,
+      }
+    );
 
     if (correctAnnotations.length > 0) {
       await wrapper.setData({ dropdownIsDisabled: true, tooltipIsShown: true });
@@ -312,12 +208,7 @@ describe("Document Top Bar", () => {
   });
 
   it("Shows arrows to navigate between documents", async () => {
-    const wrapper = mount(DocumentTopBar, {
-      store,
-      mocks: {
-        $t,
-      },
-    });
+    const wrapper = render(DocumentTopBar, false);
 
     expect(
       await wrapper
@@ -327,18 +218,15 @@ describe("Document Top Bar", () => {
   });
 
   it("Arrows are disabled if there are no documents to navigate to", async () => {
-    const wrapper = mount(DocumentTopBar, {
-      store,
-      mocks: {
-        $t,
-      },
-      data() {
-        return {
-          previousDocument: null,
-          nextDocument: null,
-        };
-      },
-    });
+    const wrapper = render(
+      DocumentTopBar,
+      false,
+      {},
+      {
+        previousDocument: null,
+        nextDocument: null,
+      }
+    );
 
     expect(
       await wrapper

--- a/tests/utils/i18n.js
+++ b/tests/utils/i18n.js
@@ -1,0 +1,2 @@
+// mock i18n so we don't need to load the library
+export const $t = () => {};

--- a/tests/utils/render.js
+++ b/tests/utils/render.js
@@ -1,0 +1,22 @@
+import { mount, shallowMount } from "@vue/test-utils";
+import { $t } from "./i18n";
+import store from "../../src/store";
+
+export const render = (component, shallow, propsData = {}, data = {}) => {
+  const values = {
+    store,
+    propsData,
+    mocks: {
+      $t,
+    },
+    data() {
+      return data;
+    },
+  };
+
+  if (shallow) {
+    return shallowMount(component, values);
+  } else {
+    return mount(component, values);
+  }
+};

--- a/tests/utils/store.js
+++ b/tests/utils/store.js
@@ -1,0 +1,33 @@
+import store from "../../src/store";
+
+export const init = () => {
+  const documentData = require("../mock/document.json");
+  const pages = [
+    require("../mock/page_1.json"),
+    require("../mock/page_2.json"),
+  ];
+  documentData.pages = pages;
+
+  Promise.resolve(
+    store.dispatch("document/setSelectedDocument", documentData),
+    store.dispatch(
+      "document/setAnnotationSets",
+      require("../mock/document.json").annotation_sets
+    ),
+    store.dispatch("document/setPublicView", false),
+    store.dispatch("document/endRecalculatingAnnotations"),
+    store.dispatch("document/endLoading")
+  );
+};
+
+// returns promise
+export const dispatch = (path, params) => {
+  return store.dispatch(path, params);
+};
+
+export const getData = (storeName) => {
+  if (store) {
+    return store.state[storeName];
+  }
+  return null;
+};

--- a/tests/utils/store.js
+++ b/tests/utils/store.js
@@ -8,15 +8,36 @@ export const init = () => {
   ];
   documentData.pages = pages;
 
+  const annotations = [];
+  const annotationSets = documentData.annotation_sets;
+  annotationSets.map((annotationSet) => {
+    annotationSet.labels.map((label) => {
+      annotations.push(...label.annotations);
+    });
+  });
+
+  // mock scale for scrolling pages
+  const scale = {
+    elementsWidth: 1,
+    client: {
+      width: 1600,
+      height: 1200,
+    },
+    viewport: {
+      width: pages[0].size[0],
+      height: pages[0].size[1],
+    },
+  };
+
   Promise.resolve(
     store.dispatch("document/setSelectedDocument", documentData),
-    store.dispatch(
-      "document/setAnnotationSets",
-      require("../mock/document.json").annotation_sets
-    ),
+    store.dispatch("document/setAnnotations", annotations),
+    store.dispatch("document/setAnnotationSets", annotationSets),
+    store.dispatch("document/setPages", pages),
     store.dispatch("document/setPublicView", false),
     store.dispatch("document/endRecalculatingAnnotations"),
-    store.dispatch("document/endLoading")
+    store.dispatch("document/endLoading"),
+    store.dispatch("display/updateScale", scale)
   );
 };
 
@@ -28,6 +49,13 @@ export const dispatch = (path, params) => {
 export const getData = (storeName) => {
   if (store) {
     return store.state[storeName];
+  }
+  return null;
+};
+
+export const getGetter = (getterName) => {
+  if (store) {
+    return store.getters[getterName];
   }
   return null;
 };


### PR DESCRIPTION
Store initialization and methods are now separated from the components unit tests.
This will help refactor mock data if needed without messing the tests and simplifying the unit tests code.