### PR TITLE
chore(deps): bump picomatch to 2.3.2 (CVE-2026-33672)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12279,10 +12279,11 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "devOptional": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -19766,7 +19767,7 @@
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
+        "picomatch": "^2.3.2"
       }
     },
     "arch": {
@@ -23862,7 +23863,7 @@
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
+        "picomatch": "^2.3.2"
       },
       "dependencies": {
         "chalk": {
@@ -24708,7 +24709,7 @@
       "devOptional": true,
       "requires": {
         "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
+        "picomatch": "^2.3.2"
       }
     },
     "mime": {
@@ -25370,9 +25371,9 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "devOptional": true
     },
     "pify": {
@@ -27979,7 +27980,7 @@
           "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
           "dev": true,
           "requires": {
-            "picomatch": "^2.2.1"
+            "picomatch": "^2.3.2"
           }
         },
         "schema-utils": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "uuid": "^14.0.0",
     "@cypress/request": {
       "uuid": "^9.0.1"
-    }
+    },
+    "picomatch": "^2.3.2"
   }
 }


### PR DESCRIPTION
## Summary
Adds override `"picomatch": "^2.3.2"` to clear medium-severity ReDoS finding (CVE-2026-33672). picomatch is transitive only in this repo.

`npm audit` reports zero picomatch vulns post-bump.

Vanta MEDIUM deadline: 2026-06-24.

## Test plan
- [ ] CI build passes on Node 16.x and 22.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)